### PR TITLE
feat(PLATF-5642): depository contracts

### DIFF
--- a/packages/ethereum-vm/deployments/addresses.prod.json
+++ b/packages/ethereum-vm/deployments/addresses.prod.json
@@ -697,6 +697,16 @@
     "create2Factory": "0x4e59b44847b379578588920ca78fbf26c0b4956c"
   },
   {
+    "name": "gensyn",
+    "chainId": 685689,
+    "compilerVersion": "0.8.28",
+    "evmVersion": "cancun",
+    "explorerUrl": "https://gensyn-mainnet.explorer.alchemy.com",
+    "verificationFlags": "--chain 685689 --verifier blockscout --verifier-url https://gensyn-mainnet.explorer.alchemy.com/api/",
+    "relayDepository": "0x4cd00e387622c35bddb9b4c962c136462338bc31",
+    "create2Factory": "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+  },
+  {
     "name": "katana",
     "chainId": 747474,
     "compilerVersion": "0.8.28",

--- a/packages/ethereum-vm/foundry.toml
+++ b/packages/ethereum-vm/foundry.toml
@@ -96,6 +96,7 @@ metacade = "${METACADE_RPC_URL}"
 ancient8 = "${ANCIENT8_RPC_URL}"
 rari = "${RARI_RPC_URL}"
 stable = "${STABLE_RPC_URL}"
+gensyn = "${GENSYN_RPC_URL}"
 # Testnets
 base-sepolia = "${BASE_SEPOLIA_RPC_URL}"
 sepolia = "${SEPOLIA_RPC_URL}"


### PR DESCRIPTION
Added `Gensyn` network support to the Ethereum VM configuration:

- `packages/ethereum-vm/deployments/addresses.prod.json`: included a new gensyn deployment entry (chain ID, compiler/EVM versions, explorer URL, verification flags, relay depository, and create2 factory).

- `packages/ethereum-vm/foundry.toml`: added the `gensyn = "${GENSYN_RPC_URL}"` RPC endpoint alongside existing mainnet RPCs.


PLATF-5642