### PR TITLE
chore: add zorro (4663) to addresses.prod.json

### DIFF
--- a/packages/ethereum-vm/deployments/addresses.prod.json
+++ b/packages/ethereum-vm/deployments/addresses.prod.json
@@ -354,6 +354,16 @@
     "create2Factory": "0x4e59b44847b379578588920ca78fbf26c0b4956c"
   },
   {
+    "name": "zorro",
+    "chainId": 4663,
+    "compilerVersion": "0.8.28",
+    "evmVersion": "cancun",
+    "explorerUrl": "https://8crv4vmq6tiu1yqr.blockscout.com",
+    "verificationFlags": "--chain 4663 --verifier blockscout --verifier-url https://8crv4vmq6tiu1yqr.blockscout.com/api",
+    "relayDepository": "0x4cd00e387622c35bddb9b4c962c136462338bc31",
+    "create2Factory": "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+  },
+  {
     "name": "mantle",
     "chainId": 5000,
     "compilerVersion": "0.8.28",


### PR DESCRIPTION
Linear: [DEC-887](https://linear.app/relayprotocol/issue/DEC-887/deploy-zorro-contracts-with-opsec-requirements)

## Summary
- Adds Zorro (chainId 4663) to `addresses.prod.json` for the prod RelayDepository.
- Same deterministic CREATE2 deployment used by all other prod chains: `0x4cd00e387622c35bddb9b4c962c136462338bc31`.
- Blockscout verification endpoint: `https://8crv4vmq6tiu1yqr.blockscout.com/api`.
